### PR TITLE
Add podspec

### DIFF
--- a/msalPlugin/react-native-msal-plugin.podspec
+++ b/msalPlugin/react-native-msal-plugin.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "10.0"
+
+  s.source       = { :git => "https://github.com/rmcfarlane82/react-native-msal-plugin.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+  s.dependency 'MSAL'
+end


### PR DESCRIPTION
A podspec in the root of a React Native library is required for autolinking to work in React Native =>0.60.0.

This podspec is based off the one in the react-native-webview repo, found here: https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec